### PR TITLE
Prepare v1.18.0: refactor CLI arguments, add --lazy-parse-fail

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+1.18.0 [2026-03-26]
+- Refactor shared CLI arguments into reusable helper functions
+- Add --lazy-parse-fail flag to query and document subcommands
+- Simplify cmd_document return flow
+
 1.17.0 [2026-03-26]
 - Fix facet list: remove phantom "closed" access_state value and stale music_heading_browse facet
 - Add music facets facet_937e and facet_937d with values

--- a/slubfind/cli.py
+++ b/slubfind/cli.py
@@ -444,7 +444,7 @@ def document_parser_class(args):
     return parser_by_format.get(args.export_format, JSONResponse)
 
 
-def cmd_query(find, args):
+def cmd_query(find, args):  # pylint: disable=too-many-return-statements
     """Handle the query subcommand."""
     if not resolve_from_url(find, args):
         return 1
@@ -472,17 +472,15 @@ def cmd_query(find, args):
     return 0
 
 
-def cmd_document(find, args):
+def cmd_document(find, args):  # pylint: disable=too-many-return-statements
     """Handle the document subcommand."""
-    exit_code = 0
     if args.show_url:
         url = find.url_document(args.document_id)
         if url is None:
             print("error: could not build document URL", file=sys.stderr)
-            exit_code = 1
-        else:
-            print(url)
-        return exit_code
+            return 1
+        print(url)
+        return 0
 
     parser_class = None if args.no_parser else document_parser_class(args)
     result = find.get_document(args.document_id, parser_class=parser_class)

--- a/slubfind/cli.py
+++ b/slubfind/cli.py
@@ -91,6 +91,53 @@ def json_dumps(obj, pretty=False):
     return json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
 
 
+def add_query_target_argument(parser):
+    """Add shared positional query argument."""
+    parser.add_argument("query", nargs="?", help="search query string")
+
+
+def add_query_source_arguments(parser):
+    """Add --from-url query source argument."""
+    parser.add_argument(
+        "--from-url",
+        help="parse query parameters from a SLUB catalog URL instead")
+
+
+def add_query_filter_arguments(parser):
+    """Add shared query filter arguments."""
+    parser.add_argument(
+        "--type", default="default", choices=SlubFind.QUERY_TYPES,
+        help="query field to search (default: default)")
+    parser.add_argument(
+        "--facet", action="append", type=parse_facet,
+        help=facet_help())
+    parser.add_argument(
+        "--sort", default="",
+        help="sort instruction, for example 'publishDateSort desc'")
+
+
+def add_query_paging_arguments(parser):
+    """Add shared paging arguments."""
+    parser.add_argument(
+        "--page",
+        type=parse_non_negative_int,
+        default=0,
+        help="result page parameter (must be >= 0; 0 uses catalog default page)")
+    parser.add_argument(
+        "--count",
+        type=parse_non_negative_int,
+        default=0,
+        help="results per page; must be >= 0 (0 uses catalog default; max 1000)")
+
+
+def add_query_selection_arguments(parser, with_paging=False):
+    """Add all shared query-like selection arguments."""
+    add_query_source_arguments(parser)
+    add_query_filter_arguments(parser)
+    if with_paging:
+        add_query_paging_arguments(parser)
+
+
 def build_parser():  # pylint: disable=too-many-statements
     """Build and return the argument parser."""
     parser = argparse.ArgumentParser(
@@ -154,29 +201,8 @@ def build_parser():  # pylint: disable=too-many-statements
             "\"https://katalog.slub-dresden.de/?tx_find_find%5Bq%5D%5Bdefault%5D=manfred+bonitz\""
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    query_parser.add_argument("query", nargs="?", help="search query string")
-    query_parser.add_argument(
-        "--from-url",
-        help="parse query parameters from a SLUB catalog URL instead")
-    query_parser.add_argument(
-        "--type", default="default", choices=SlubFind.QUERY_TYPES,
-        help="query field to search (default: default)")
-    query_parser.add_argument(
-        "--facet", action="append", type=parse_facet,
-        help=facet_help())
-    query_parser.add_argument(
-        "--page",
-        type=parse_non_negative_int,
-        default=0,
-        help="result page parameter (must be >= 0; 0 uses catalog default page)")
-    query_parser.add_argument(
-        "--count",
-        type=parse_non_negative_int,
-        default=0,
-        help="results per page; must be >= 0 (0 uses catalog default; max 1000)")
-    query_parser.add_argument(
-        "--sort", default="",
-        help="sort instruction, for example 'publishDateSort desc'")
+    add_query_target_argument(query_parser)
+    add_query_selection_arguments(query_parser, with_paging=True)
     query_parser.add_argument(
         "--export-format",
         default="app",
@@ -193,6 +219,10 @@ def build_parser():  # pylint: disable=too-many-statements
         "--no-parser",
         action="store_true",
         help="skip response parsing and print raw server output")
+    query_parser.add_argument(
+        "--lazy-parse-fail",
+        action="store_true",
+        help="return exit code 0 with no output when parsed output is invalid")
     query_parser.add_argument(
         "--pretty",
         action="store_true",
@@ -231,6 +261,10 @@ def build_parser():  # pylint: disable=too-many-statements
         "--no-parser",
         action="store_true",
         help="skip response parsing and print raw server output")
+    doc_parser.add_argument(
+        "--lazy-parse-fail",
+        action="store_true",
+        help="return exit code 0 with no output when parsed output is invalid")
     not_found_group = doc_parser.add_mutually_exclusive_group()
     not_found_group.add_argument(
         "--strict-not-found",
@@ -261,24 +295,13 @@ def build_parser():  # pylint: disable=too-many-statements
             "  slubfind scroll \"manfred bonitz\" --stream | jq .id"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    scroll_parser.add_argument("query", nargs="?", help="search query string")
-    scroll_parser.add_argument(
-        "--from-url",
-        help="parse query parameters from a SLUB catalog URL instead")
-    scroll_parser.add_argument(
-        "--type", default="default", choices=SlubFind.QUERY_TYPES,
-        help="query field to search (default: default)")
-    scroll_parser.add_argument(
-        "--facet", action="append", type=parse_facet,
-        help=facet_help())
+    add_query_target_argument(scroll_parser)
+    add_query_selection_arguments(scroll_parser)
     scroll_parser.add_argument(
         "--batch",
         type=parse_positive_int,
         default=20,
         help="number of records to fetch per request; must be > 0 (default: 20)")
-    scroll_parser.add_argument(
-        "--sort", default="",
-        help="sort instruction, for example 'publishDateSort desc'")
     scroll_parser.add_argument(
         "--stream", action="store_true",
         help="print one JSON object per line instead of one JSON array")
@@ -311,30 +334,8 @@ def build_parser():  # pylint: disable=too-many-statements
             "\"https://katalog.slub-dresden.de/?tx_find_find%5Bq%5D%5Bdefault%5D=manfred+bonitz\""
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    solr_params_parser.add_argument(
-        "query", nargs="?", help="search query string")
-    solr_params_parser.add_argument(
-        "--from-url",
-        help="parse query parameters from a SLUB catalog URL instead")
-    solr_params_parser.add_argument(
-        "--type", default="default", choices=SlubFind.QUERY_TYPES,
-        help="query field to search (default: default)")
-    solr_params_parser.add_argument(
-        "--facet", action="append", type=parse_facet,
-        help=facet_help())
-    solr_params_parser.add_argument(
-        "--page",
-        type=parse_non_negative_int,
-        default=0,
-        help="result page parameter (must be >= 0; 0 uses catalog default page)")
-    solr_params_parser.add_argument(
-        "--count",
-        type=parse_non_negative_int,
-        default=0,
-        help="results per page; must be >= 0 (0 uses catalog default; max 1000)")
-    solr_params_parser.add_argument(
-        "--sort", default="",
-        help="sort instruction, for example 'publishDateSort desc'")
+    add_query_target_argument(solr_params_parser)
+    add_query_selection_arguments(solr_params_parser, with_paging=True)
     solr_params_parser.add_argument(
         "--pretty",
         action="store_true",
@@ -355,30 +356,8 @@ def build_parser():  # pylint: disable=too-many-statements
             "\"https://katalog.slub-dresden.de/?tx_find_find%5Bq%5D%5Bdefault%5D=manfred+bonitz\""
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    solr_request_parser.add_argument(
-        "query", nargs="?", help="search query string")
-    solr_request_parser.add_argument(
-        "--from-url",
-        help="parse query parameters from a SLUB catalog URL instead")
-    solr_request_parser.add_argument(
-        "--type", default="default", choices=SlubFind.QUERY_TYPES,
-        help="query field to search (default: default)")
-    solr_request_parser.add_argument(
-        "--facet", action="append", type=parse_facet,
-        help=facet_help())
-    solr_request_parser.add_argument(
-        "--page",
-        type=parse_non_negative_int,
-        default=0,
-        help="result page parameter (must be >= 0; 0 uses catalog default page)")
-    solr_request_parser.add_argument(
-        "--count",
-        type=parse_non_negative_int,
-        default=0,
-        help="results per page; must be >= 0 (0 uses catalog default; max 1000)")
-    solr_request_parser.add_argument(
-        "--sort", default="",
-        help="sort instruction, for example 'publishDateSort desc'")
+    add_query_target_argument(solr_request_parser)
+    add_query_selection_arguments(solr_request_parser, with_paging=True)
 
     return parser
 
@@ -441,6 +420,19 @@ def is_document_not_found(result):
     return False
 
 
+def is_parse_failure(result):
+    """Return True when parser-backed output failed to parse."""
+    if not hasattr(result, "raw") or result.raw is not None:
+        return False
+    if not hasattr(result, "plain"):
+        return True
+    try:
+        json.loads(result.plain)
+    except (TypeError, json.JSONDecodeError):
+        return True
+    return False
+
+
 def document_parser_class(args):
     """Return parser class for the document command based on export format."""
     parser_by_format = {
@@ -467,6 +459,11 @@ def cmd_query(find, args):
     if args.no_parser:
         print(result.plain if hasattr(result, "plain") else result)
         return 0
+    if is_parse_failure(result):
+        if args.lazy_parse_fail:
+            return 0
+        print("error: failed to parse response", file=sys.stderr)
+        return 1
     data = result.raw if hasattr(result, "raw") else result
     if args.no_facets and isinstance(data, dict):
         data = {k: v for k, v in data.items()
@@ -502,6 +499,11 @@ def cmd_document(find, args):
 
     if args.no_parser:
         print(result.plain if hasattr(result, "plain") else result)
+    elif is_parse_failure(result):
+        if args.lazy_parse_fail:
+            return 0
+        print("error: failed to parse response", file=sys.stderr)
+        return 1
     else:
         data = result.raw if hasattr(result, "raw") else result
         print(json_dumps(data, pretty=args.pretty))

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 
 from slubfind.cli import (
     json_dumps,
+    make_find,
     main,
     merge_facets,
     parse_facet,
@@ -297,12 +298,41 @@ def test_cmd_query_no_facets_non_dict(capsys):
 
 def test_cmd_query_no_parser(capsys):
     result = MagicMock()
-    result.plain = '{"raw":"text"}'
+    result.plain = '{"raw":'
     find = MagicMock()
     find.get_query.return_value = result
     code = _run(["query", "--no-parser", "python"], find, capsys)
     assert code == 0
-    assert '{"raw":"text"}' in capsys.readouterr().out
+    assert '{"raw":' in capsys.readouterr().out
+
+
+def test_cmd_query_parse_failure_strict(capsys):
+    find = MagicMock()
+    find.get_query.return_value = _make_result(None)
+    code = _run(["query", "python"], find, capsys)
+    assert code == 1
+    assert "failed to parse response" in capsys.readouterr().err
+
+
+def test_cmd_query_parse_failure_lazy(capsys):
+    find = MagicMock()
+    find.get_query.return_value = _make_result(None)
+    code = _run(["query", "--lazy-parse-fail", "python"], find, capsys)
+    assert code == 0
+    io = capsys.readouterr()
+    assert io.out == ""
+    assert io.err == ""
+
+
+def test_cmd_query_valid_json_null_is_not_parse_failure(capsys):
+    result = MagicMock()
+    result.raw = None
+    result.plain = "null"
+    find = MagicMock()
+    find.get_query.return_value = result
+    code = _run(["query", "python"], find, capsys)
+    assert code == 0
+    assert capsys.readouterr().out.strip() == "null"
 
 
 # ---------------------------------------------------------------------------
@@ -349,12 +379,30 @@ def test_cmd_document_pretty(capsys):
 
 def test_cmd_document_no_parser(capsys):
     result = MagicMock()
-    result.plain = '{"raw":"doc"}'
+    result.plain = '{"raw":'
     find = MagicMock()
     find.get_document.return_value = result
     code = _run(["document", "--no-parser", "0-123"], find, capsys)
     assert code == 0
-    assert '{"raw":"doc"}' in capsys.readouterr().out
+    assert '{"raw":' in capsys.readouterr().out
+
+
+def test_cmd_document_parse_failure_strict(capsys):
+    find = MagicMock()
+    find.get_document.return_value = _make_result(None)
+    code = _run(["document", "0-123"], find, capsys)
+    assert code == 1
+    assert "failed to parse response" in capsys.readouterr().err
+
+
+def test_cmd_document_parse_failure_lazy(capsys):
+    find = MagicMock()
+    find.get_document.return_value = _make_result(None)
+    code = _run(["document", "--lazy-parse-fail", "0-123"], find, capsys)
+    assert code == 0
+    io = capsys.readouterr()
+    assert io.out == ""
+    assert io.err == ""
 
 
 def test_cmd_document_empty_id_default_mode(capsys):
@@ -429,6 +477,18 @@ def test_cmd_document_no_parser_passes_none_parser_class(capsys):
     code = _run(["document", "--no-parser", "0-123"], find, capsys)
     assert code == 0
     _, kwargs = find.get_document.call_args
+    assert kwargs["parser_class"] is None
+
+
+def test_make_find_no_parser_sets_parser_class_none():
+    args = argparse.Namespace(
+        url="https://example.test",
+        export_format="app",
+        export_page=1369315142,
+        no_parser=True)
+    with patch("slubfind.cli.SlubFind") as slub_find_cls:
+        make_find(args)
+    _, kwargs = slub_find_cls.call_args
     assert kwargs["parser_class"] is None
 
 


### PR DESCRIPTION
## Summary
- Extract duplicated query/filter/paging argument definitions into reusable helper functions (`add_query_target_argument`, `add_query_source_arguments`, `add_query_filter_arguments`, `add_query_paging_arguments`, `add_query_selection_arguments`)
- Add `--lazy-parse-fail` option to `query` and `document` subcommands for graceful handling of parse failures (exit 0, no output)
- Simplify `cmd_document` return flow by inlining exit codes

## Test plan
- [x] All 166 tests pass
- [x] Coverage at 95%
- [x] flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)